### PR TITLE
Show Load Balancing Feature of ECS

### DIFF
--- a/app/service.rb
+++ b/app/service.rb
@@ -1,5 +1,6 @@
 require 'sinatra'
 require "sinatra/namespace"
+require 'socket'
 
 class Book
     @@books = [
@@ -18,11 +19,11 @@ class Book
 end
 
 get '/' do
-    'Healthy!!!'
+    'Healthy via ' + Socket.gethostname
 end
 
 get '/stat' do
-    'Healthy!!!'
+    'Healthy via ' + Socket.gethostname
 end
 
 namespace '/api' do


### PR DESCRIPTION
Return hostname for / and /stat endpoints response to show the load balancing between ECS container.

Example: Hitting the endpoint returns the hostname of the container serving the request
```
> curl http://books-api-1371286301.us-west-1.elb.amazonaws.com/
Healthy ip-10-20-12-59.us-west-1.compute.internal⏎                                                                                                                         

> curl http://books-api-1371286301.us-west-1.elb.amazonaws.com/
Healthy ip-10-20-77-172.us-west-1.compute.internal⏎                                                                                                                        
```

If it makes sense latest code can be deployed as follows:

- Build the new docker build: `cd app; docker build -t books-api .`
- Push the image to ECR `docker push 316757257260.dkr.ecr.us-west-1.amazonaws.com/books-api:latest`
- Create new task definition revision and update the service which will roll out the new app docker image. **This can be done obviously from cloudformation as well**